### PR TITLE
Add AI chat feature (backend, frontend tab, OpenAI integration)

### DIFF
--- a/NeuroTuneFrontend/app/(app)/_layout.jsx
+++ b/NeuroTuneFrontend/app/(app)/_layout.jsx
@@ -3,12 +3,12 @@ import { Tabs } from "expo-router";
 export default function appLayout() {
   return (
     <Tabs>
+      <Tabs.Screen name="chat" options={{ title: "Chat" }} />
       <Tabs.Screen name="create" options={{ title: "Create" }} />
-      <Tabs.Screen name="list" options={{ title: "List" }} />
+      <Tabs.Screen name="list" options={{ title: "Read" }} />
       <Tabs.Screen name="update" options={{ title: "Update" }} />
       <Tabs.Screen name="delete" options={{ title: "Delete"}} />
-      <Tabs.Screen name="logout" options={{ title: "Logout" }} />
-      <Tabs.Screen name="search" options={{ title: "Search"}} />
+      <Tabs.Screen name="logout" options={{ title: "Profile" }} />
     </Tabs>
   );
 }

--- a/NeuroTuneFrontend/app/(app)/chat.jsx
+++ b/NeuroTuneFrontend/app/(app)/chat.jsx
@@ -1,0 +1,84 @@
+import React, { useState } from "react";
+import {
+  View,
+  Text,
+  TextInput,
+  Button,
+  ScrollView,
+  StyleSheet,
+  ActivityIndicator
+} from "react-native";
+import BASE_URL from "../../constants/api";
+
+export default function ChatScreen() {
+  const [message, setMessage] = useState("");
+  const [reply, setReply] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  const handleAsk = async () => {
+    if (!message.trim()) return;
+
+    setLoading(true);
+    try {
+      const res = await fetch(`${BASE_URL}/chat/ask`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ message })
+      });
+
+      const data = await res.json();
+      setReply(data.reply || "No response.");
+    } catch (err) {
+      console.error("Error fetching chat:", err);
+      setReply("Something went wrong.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <ScrollView contentContainerStyle={styles.container}>
+      <Text style={styles.title}>🎧 AI Music Chat</Text>
+      <Text style={styles.sub}>Ask the bot for a song or playlist based on a mood or vibe.</Text>
+
+      <TextInput
+        style={styles.input}
+        placeholder="e.g. Suggest a playlist for studying"
+        value={message}
+        onChangeText={setMessage}
+      />
+
+      {loading ? (
+        <ActivityIndicator style={styles.loader} />
+      ) : (
+        <Button title="Ask" onPress={handleAsk} />
+      )}
+
+      <Text style={styles.responseTitle}>🎤 AI Reply:</Text>
+      <Text style={styles.response}>{reply}</Text>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { padding: 20 },
+  title: { fontSize: 24, fontWeight: "bold", marginBottom: 10, textAlign: "center" },
+  sub: { fontSize: 14, marginBottom: 20, textAlign: "center" },
+  input: {
+    borderWidth: 1, borderColor: "#ccc", borderRadius: 8,
+    padding: 10, marginBottom: 10
+  },
+  responseTitle: {
+    marginTop: 20,
+    fontSize: 18,
+    fontWeight: "600",
+  },
+  response: {
+    fontSize: 16,
+    color: "#444",
+    marginTop: 10,
+  },
+  loader: {
+    marginVertical: 20
+  }
+});

--- a/htdocs/Controller/Api/ChatController.php
+++ b/htdocs/Controller/Api/ChatController.php
@@ -1,0 +1,36 @@
+<?php
+require_once PROJECT_ROOT_PATH . "/Model/ChatModel.php";
+
+class ChatController extends BaseController
+{
+    public function askAction()
+    {
+        $strErrorDesc = '';
+        $requestMethod = $_SERVER["REQUEST_METHOD"];
+        $requestData = $this->getRequestData();
+
+        if (strtoupper($requestMethod) == 'POST') {
+            try {
+                if (empty($requestData['message'])) {
+                    throw new Exception("Message is required");
+                }
+
+                $chatModel = new ChatModel();
+                $reply = $chatModel->getChatResponse($requestData['message']);
+                $responseData = json_encode(["reply" => $reply]);
+            } catch (Exception $e) {
+                $strErrorDesc = $e->getMessage();
+                $strErrorHeader = 'HTTP/1.1 400 Bad Request';
+            }
+        } else {
+            $strErrorDesc = 'Only POST method is supported';
+            $strErrorHeader = 'HTTP/1.1 405 Method Not Allowed';
+        }
+
+        if (!$strErrorDesc) {
+            $this->sendOutput($responseData, ['Content-Type: application/json']);
+        } else {
+            $this->sendOutput(json_encode(['error' => $strErrorDesc]), ['Content-Type: application/json', $strErrorHeader]);
+        }
+    }
+}

--- a/htdocs/Model/ChatModel.php
+++ b/htdocs/Model/ChatModel.php
@@ -1,0 +1,49 @@
+<?php
+require_once PROJECT_ROOT_PATH . "/inc/config.php"; // 
+
+class ChatModel
+{
+    public function getChatResponse($message)
+    {
+        $url = 'https://api.openai.com/v1/chat/completions';
+
+        $headers = [
+            'Authorization: Bearer ' . OPENAI_API_KEY,
+            'Content-Type: application/json'
+        ];
+
+        $data = [
+            'model' => 'gpt-4o-mini', 
+            'messages' => [
+                [
+                    'role' => 'system',
+                    'content' => 'You suggest songs based on mood or vibe.'
+                ],
+                [
+                    'role' => 'user',
+                    'content' => $message
+                ]
+            ],
+            'temperature' => 0.8,
+            'max_tokens' => 150 
+        ];
+
+        $ch = curl_init($url);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
+        curl_setopt($ch, CURLOPT_POST, true);
+        curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode($data));
+
+        $response = curl_exec($ch);
+        curl_close($ch);
+
+        $result = json_decode($response, true);
+
+        if (isset($result['choices'][0]['message']['content'])) {
+            return $result['choices'][0]['message']['content'];
+        } else {
+            error_log("OpenAI API error: " . $response);
+            return "Sorry, I couldn’t come up with a recommendation.";
+        }
+    }
+}

--- a/htdocs/inc/bootstrap.php
+++ b/htdocs/inc/bootstrap.php
@@ -12,3 +12,4 @@ require_once PROJECT_ROOT_PATH . "/Model/Database.php";
 require_once PROJECT_ROOT_PATH . "/Model/UserModel.php";
 require_once PROJECT_ROOT_PATH . "/Model/RatingModel.php";
 require_once PROJECT_ROOT_PATH . "/Model/DataModel.php";
+require_once PROJECT_ROOT_PATH . "/Model/ChatModel.php";

--- a/htdocs/inc/config.php
+++ b/htdocs/inc/config.php
@@ -3,3 +3,4 @@ define("DB_HOST", "localhost");
 define("DB_USERNAME", "root");
 define("DB_PASSWORD", "");
 define("DB_DATABASE_NAME", "app_db");
+define("OPENAI_API_KEY", "api-key-here");

--- a/htdocs/index.php
+++ b/htdocs/index.php
@@ -6,12 +6,29 @@ if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
     header("Access-Control-Allow-Origin: *");
     header("Access-Control-Allow-Methods: GET, POST, PUT, DELETE, OPTIONS");
     header("Access-Control-Allow-Headers: Content-Type, Authorization");
-    exit(0); // Exit without triggering controller
+    exit(0);
 }
 
 $uri = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH);
-$uri = explode('/', $uri);
 
+// Special case: /chat/ask — GPT chatbot
+if (preg_match('/\/chat\/ask$/', $uri)) {
+    require PROJECT_ROOT_PATH . "/Controller/Api/ChatController.php";
+    $chatController = new ChatController();
+    $chatController->askAction();
+    exit();
+}
+
+// Special case: /recommendation/auto
+if (preg_match('/\/recommendation\/auto$/', $uri)) {
+    require PROJECT_ROOT_PATH . "/Controller/Api/RecommendationController.php";
+    $recController = new RecommendationController();
+    $recController->autoAction();
+    exit();
+}
+
+// General route handling
+$uri = explode('/', $uri);
 if (!isset($uri[2]) || !isset($uri[3])) {
     header("HTTP/1.1 404 Not Found");
     exit();
@@ -29,3 +46,4 @@ require $controllerFile;
 $controller = new $controllerName();
 $strMethodName = $uri[3] . 'Action';
 $controller->{$strMethodName}();
+


### PR DESCRIPTION
This PR adds a new **AI-powered chat feature** to the app, enabling users to interact with a chatbot that recommends songs based on mood, vibe, or activity. The chatbot uses OpenAI’s GPT model (via API) to provide smart, conversational suggestions.

What's Included:
- `ChatModel.php`: Backend logic using OpenAI's Chat Completion API.
- `ChatController.php`: Handles `/chat/ask` POST requests with a user message.
- `chat.jsx`: New React Native screen where users can chat and receive music suggestions.
- Updated `_layout.jsx` to include the Chat tab.
- Minor edits to `bootstrap.php` and `config.php` to load the OpenAI key.

API Key (IMPORTANT)
GitHub blocks commits that contain secrets — so the API key currently **won’t work**.  
To test locally:
1. I’ll share the **real OpenAI key** with you privately.
2. Paste it inside:  
   `htdocs/inc/config.php`  
   ```php
   define("OPENAI_API_KEY", "key-here");
   ```
3. You can now test it using Postman or the mobile frontend (`/chat/ask` endpoint).


Screenshot of Postman Test:

<img width="874" alt="Screenshot 2025-04-30 at 7 24 53 AM" src="https://github.com/user-attachments/assets/8f33617d-1c85-4dda-a8cc-a7a527e413cd" />
